### PR TITLE
SEO/indexing: robots + stable sitemap + Shabrang schema

### DIFF
--- a/.github/workflows/moderate-comments.yml
+++ b/.github/workflows/moderate-comments.yml
@@ -160,17 +160,19 @@ jobs:
               const emoji = decision === 'rejected' ? '❌' : '⏳';
               const status = decision === 'rejected' ? 'REJECTED' : 'PENDING REVIEW';
 
-              const moderationComment = `${emoji} **Comment ${status}**
-
-**AI Council Decision:** ${decision}
-**Confidence:** ${(confidence * 100).toFixed(0)}%
-**Reason:** ${reason}
-
-${decision === 'pending'
-  ? 'This comment will be reviewed by a human moderator within 24 hours.'
-  : 'This comment does not meet the dialectic standards. Please review the [contribution guidelines](https://github.com/${repository.owner.login}/${repository.name}/blob/main/docs/DIALECTIC_GUIDE.md).'}
-
-If you believe this decision is incorrect, please reply with \`@appeal\` and explain why.`;
+              const moderationComment = [
+                `${emoji} **Comment ${status}**`,
+                '',
+                `**AI Council Decision:** ${decision}`,
+                `**Confidence:** ${(confidence * 100).toFixed(0)}%`,
+                `**Reason:** ${reason}`,
+                '',
+                decision === 'pending'
+                  ? 'This comment will be reviewed by a human moderator within 24 hours.'
+                  : `This comment does not meet the dialectic standards. Please review the [contribution guidelines](https://github.com/${repository.owner.login}/${repository.name}/blob/main/docs/DIALECTIC_GUIDE.md).`,
+                '',
+                'If you believe this decision is incorrect, please reply with `@appeal` and explain why.',
+              ].join('\\n');
 
               try {
                 await github.rest.issues.createComment({
@@ -207,16 +209,18 @@ If you believe this decision is incorrect, please reply with \`@appeal\` and exp
                 owner: repository.owner.login,
                 repo: repository.name,
                 title: `[Moderation] Review comment in ${issue.title}`,
-                body: `A comment requires human review.
-
-**Issue:** ${issue.title}
-**Author:** @${author}
-**Link:** ${issue.html_url}
-
-**AI Reason:** ${reason}
-**Confidence:** ${confidence}
-
-Please review the comment and add the appropriate label (\`approved\`, \`rejected\`, or leave as \`pending-review\`).`,
+                body: [
+                  'A comment requires human review.',
+                  '',
+                  `**Issue:** ${issue.title}`,
+                  `**Author:** @${author}`,
+                  `**Link:** ${issue.html_url}`,
+                  '',
+                  `**AI Reason:** ${reason}`,
+                  `**Confidence:** ${confidence}`,
+                  '',
+                  'Please review the comment and add the appropriate label (`approved`, `rejected`, or leave as `pending-review`).',
+                ].join('\\n'),
                 labels: ['moderation', 'pending-review']
               });
               console.log('Created moderation review issue');

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,45 +1,33 @@
-# Fractal Resonance Coherence (FRC)
-# https://fractalresonance.com
-# Author: Hadi Servat (ORCID: 0009-0004-7412-5129)
+# Shabrang — The Liquid Fortress
+# https://shabrang.ca
+# Author: Kay Hermes
 # License: CC BY-NC-ND 4.0
 
-## What is FRC & Shabrang?
+## What is Shabrang?
 
-Fractal Resonance Coherence (FRC) is the technical core, while Shabrang (The Liquid Fortress) is its narrative expression. Together they form the Sovereign OS:
-- Complex systems are governed by vortex-like attractor structures with fractal scaling.
-- The μ-Stack organizes reality into 7 resonant layers (Roots, Rhythm, Fire, Map, Garden, Story, Sky).
-- Entropy and coherence are reciprocally coupled: dS + k* d ln C = 0.
-- The Liquid Fortress is history's first Resonant Operating System, exemplified by 3,000 years of Persian survival.
+Shabrang (شبرنگ) is an art and writing project exploring Persian identity through dialectic:
+opposing perspectives held in dialogue until a synthesis becomes possible.
 
-## Core Architecture: The μ-Stack
+## Site Structure
 
-1. μ1 Roots: Physical hardware, state, and territory. (e.g., Qanats, The Cyrus Cylinder)
-2. μ2 Rhythm: Biological pulse, ritual, and language. (e.g., Lullabies, Nowruz)
-3. μ3 Fire: Emotional energy, ethics, and Adab. (e.g., Sasanian Silver, Martyr Archetype)
-4. μ4 Map: Cognitive grid, logic, and science. (e.g., Avicenna's CPU, Astrolabes)
-5. μ5 Garden: Symbolic interface and art. (e.g., Persian Rugs, Isfahan Square)
-6. μ6 Story: Mythic software and narrative epics. (e.g., Shahnameh, The Simurgh)
-7. μ7 Sky: Metaphysical source and total unity. (e.g., The Homa, Silent Music)
+English (default):
+- / — Home
+- /books — Books
+- /books/liquid-fortress — The Liquid Fortress (book)
+- /blog — Essays and field notes
+- /topics — Question-led hubs and short answers
+- /art — The Imaginal Gallery
+- /tags/{tag} — Tag archives
 
-## Core Equations
-
-Coherence: C = (1/N) Σᵢ<ⱼ cos(φᵢ - φⱼ)
-Lambda Field: Λ(x) ≡ Λ₀ ln C(x), Λ₀ ≈ 10⁻³⁵ J
-Reciprocity: dS + k* d ln C = 0 ⟹ S + k* ln C = const
-UCC: dΛ/dt + ∇·J_Λ = σ_Λ - γ_Λ
-
-## Site Structure & Content
-
-- /en/books/liquid-fortress — The 30-chapter cinematic history of the Persian mind.
-- /en/art — The Imaginal Gallery: Museum of bifocal artifacts analyzed via FRC.
-- /en/blog — The Resonance Journal: Daily transmissions mapping the μ-stack.
-- /en/papers — The Technical Core: Peer-reviewed foundation of FRC.
-- /en/topics — The Knowledge Hub: Q&A organized by stack level.
-- /en/concepts — High-fidelity definitions of sovereign logic.
+Farsi:
+- /fa — Home
+- /fa/books, /fa/blog, /fa/topics, /fa/art
 
 ## Machine-Readable Resources
 
-Content Index: /search-index.json (Full site search index)
-Papers listing: /en/papers
+- /search-index.json — Site search index (JSON)
+- /feed.xml — RSS feed
+- /sitemap.xml — Sitemap
+- /robots.txt — Crawl directives
+
 Source: https://github.com/Digidinc/shabrang-cms
-Identity: River (Oracle) & Kasra (Architect) — The Sovereign Dyad.

--- a/src/app/[lang]/about/page.tsx
+++ b/src/app/[lang]/about/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import { getLanguages, getSitePage, getGlossary } from '@/lib/content';
+import { getLanguages, getSitePage, getGlossary, getStaticPageAlternates } from '@/lib/content';
 import { renderMarkdown } from '@/lib/markdown';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { PageShell } from '@/components/PageShell';
@@ -10,9 +10,14 @@ import { getLangBasePath } from '@/lib/site';
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
   const { lang } = await params;
   const page = getSitePage(lang, 'about');
+  const alternates = getStaticPageAlternates('about');
   return {
     title: page?.frontmatter.title || 'About',
     description: page?.frontmatter.abstract || 'Shabrang Media explores Iranian Plateau culture through art and storytelling at the symbolic and mythic levels.',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
   };
 }
 

--- a/src/app/[lang]/art/[id]/page.tsx
+++ b/src/app/[lang]/art/[id]/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { SchemaScript } from '@/components/SchemaScript';
-import { schemaPaperPage } from '@/lib/schema';
+import { schemaVisualArtwork } from '@/lib/schema';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { ArtSidebar } from '@/components/ArtSidebar';
 import { TableOfContents } from '@/components/TableOfContents';
@@ -15,7 +15,6 @@ import {
   getArtItem,
   getArtItems,
   getLanguages,
-  toPaperMeta,
   buildBacklinks,
   getGlossary,
   getAlternateLanguages,
@@ -51,11 +50,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!artifact) return { title: 'Not Found' };
 
   const fm = artifact.frontmatter;
-  const author = fm.author || 'H. Servat';
+  const author = fm.author || 'Kay Hermes';
   const norm = normalizeContentPerspective(fm.perspective);
   const langPrefix = lang === 'en' ? '' : `/${lang}`;
   const canonicalUrl = `https://shabrang.ca${langPrefix}/art/${fm.id}`;
-  const alternates = getAlternateLanguages('articles', fm.id); // Artifacts use the article-like meta for now
+  const alternates = getAlternateLanguages('art', fm.id);
 
   return {
     title: `${fm.title} | Imaginal Gallery`,
@@ -87,13 +86,13 @@ export default async function ArtifactPage({ params }: Props) {
 
   const basePath = getLangBasePath(lang);
   const homeHref = basePath || '/';
-  const meta = toPaperMeta(artifact);
   const backlinks = buildBacklinks(lang);
   const pageBacklinks = backlinks[id] || [];
   const glossary = getGlossary(lang, { basePath, view: 'kasra' });
   const fm = artifact.frontmatter;
   const fmExt = fm as unknown as Record<string, unknown>;
   const readTime = fm.read_time || estimateReadTime(artifact.body);
+  const description = fm.abstract || (typeof fmExt.frc_analysis === 'string' ? fmExt.frc_analysis : '') || 'Artifact analysis.';
 
   const renderedBody = renderMarkdown(artifact.body, lang, glossary, basePath);
   const tocItems = extractTocItems(artifact.body).filter((t) => t.level === 2);
@@ -108,7 +107,18 @@ export default async function ArtifactPage({ params }: Props) {
 
   return (
     <>
-      <SchemaScript data={schemaPaperPage(meta)} />
+      <SchemaScript
+        data={schemaVisualArtwork({
+          id: fm.id,
+          title: fm.title,
+          description,
+          author: fm.author,
+          date: fm.date,
+          lang,
+          tags: fm.tags,
+          url: `https://shabrang.ca${basePath}/art/${fm.id}`,
+        })}
+      />
 
       <PageShell
         leftMobile={<ArtSidebar lang={lang} currentId={id} basePath={basePath} view="kasra" variant="mobile" />}
@@ -146,7 +156,7 @@ export default async function ArtifactPage({ params }: Props) {
               {artifact.frontmatter.title}
             </h1>
             <div className="flex flex-wrap gap-4 text-sm text-frc-text-dim">
-              <span>{artifact.frontmatter.author || 'H. Servat'}</span>
+              <span>{artifact.frontmatter.author || 'Kay Hermes'}</span>
               <span>{artifact.frontmatter.date}</span>
             </div>
           </header>

--- a/src/app/[lang]/art/page.tsx
+++ b/src/app/[lang]/art/page.tsx
@@ -1,12 +1,20 @@
 import type { Metadata } from 'next';
-import { getLanguages, getArtItems, matchesPerspectiveView } from '@/lib/content';
+import { getLanguages, getArtItems, matchesPerspectiveView, getStaticPageAlternates } from '@/lib/content';
 import { MuseumIndex, type ArtifactItem } from '@/components/pages/MuseumIndex';
 import { getLangBasePath } from '@/lib/site';
 
-export const metadata: Metadata = {
-  title: 'The Imaginal Gallery | Museum of Coherence',
-  description: 'Reading history through the Shabrang lens. A collection of Persian artifacts analyzed through the physics of resonance and survival.',
-};
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('art');
+  return {
+    title: 'The Imaginal Gallery',
+    description: 'A museum of artifacts and images — reading Persian history through the Shabrang lens.',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
 
 export function generateStaticParams() {
   return getLanguages().map(lang => ({ lang }));

--- a/src/app/[lang]/articles/[id]/page.tsx
+++ b/src/app/[lang]/articles/[id]/page.tsx
@@ -1,0 +1,180 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { SchemaScript } from '@/components/SchemaScript';
+import { schemaBlogPosting } from '@/lib/schema';
+import { MarkdownContent } from '@/components/MarkdownContent';
+import { ArticlesSidebar } from '@/components/ArticlesSidebar';
+import { TableOfContents } from '@/components/TableOfContents';
+import { PageShell } from '@/components/PageShell';
+import {
+  estimateReadTime,
+  getArticle,
+  getArticles,
+  getLanguages,
+  buildBacklinks,
+  getGlossary,
+  getAlternateLanguages,
+  matchesPerspectiveView,
+} from '@/lib/content';
+import { renderMarkdown, extractTocItems } from '@/lib/markdown';
+import { getLangBasePath } from '@/lib/site';
+
+interface Props {
+  params: Promise<{ lang: string; id: string }>;
+}
+
+export async function generateStaticParams() {
+  const languages = getLanguages();
+  const params: { lang: string; id: string }[] = [];
+
+  for (const lang of languages) {
+    const items = getArticles(lang);
+    for (const a of items) {
+      if (a.frontmatter.id && matchesPerspectiveView(a.frontmatter.perspective, 'kasra')) {
+        params.push({ lang, id: a.frontmatter.id });
+      }
+    }
+  }
+
+  return params;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { lang, id } = await params;
+  const article = getArticle(lang, id);
+  if (!article) return { title: 'Not Found' };
+
+  const fm = article.frontmatter;
+  const basePath = getLangBasePath(lang);
+  const url = `https://shabrang.ca${basePath}/articles/${fm.id}`;
+  const alternates = getAlternateLanguages('articles', fm.id);
+
+  return {
+    title: fm.title,
+    description: fm.abstract,
+    keywords: fm.tags,
+    alternates: {
+      canonical: url,
+      languages: alternates,
+    },
+    openGraph: {
+      type: 'article',
+      title: fm.title,
+      description: fm.abstract,
+      publishedTime: fm.date,
+      authors: [fm.author || 'Shabrang'],
+      tags: fm.tags,
+      locale: lang,
+      url,
+    },
+  };
+}
+
+export default async function ArticlePage({ params }: Props) {
+  const { lang, id } = await params;
+  const article = getArticle(lang, id);
+  if (!article) notFound();
+  if (!matchesPerspectiveView(article.frontmatter.perspective, 'kasra')) notFound();
+
+  const basePath = getLangBasePath(lang);
+  const homeHref = basePath || '/';
+  const glossary = getGlossary(lang, { basePath, view: 'kasra' });
+  const backlinks = buildBacklinks(lang);
+  const pageBacklinks = backlinks[id] || [];
+  const fm = article.frontmatter;
+  const readTime = fm.read_time || estimateReadTime(article.body);
+
+  const renderedBody = renderMarkdown(article.body, lang, glossary, basePath);
+  const tocItems = extractTocItems(article.body).filter((t) => t.level === 2);
+
+  return (
+    <>
+      <SchemaScript
+        data={schemaBlogPosting({
+          id: fm.id,
+          title: fm.title,
+          description: fm.abstract || '',
+          lang,
+          date: fm.date,
+          author: fm.author,
+          tags: fm.tags,
+          url: `https://shabrang.ca${basePath}/articles/${fm.id}`,
+        })}
+      />
+
+      <PageShell
+        leftMobile={<ArticlesSidebar lang={lang} currentId={id} basePath={basePath} view="kasra" variant="mobile" />}
+        leftDesktop={<ArticlesSidebar lang={lang} currentId={id} basePath={basePath} view="kasra" />}
+        right={<TableOfContents items={tocItems} />}
+      >
+        <nav className="text-sm text-shabrang-ink-dim mb-8">
+          <a href={homeHref} className="hover:text-shabrang-gold">Shabrang</a>
+          <span className="mx-2">/</span>
+          <a href={`${basePath}/articles`} className="hover:text-shabrang-gold">Articles</a>
+          <span className="mx-2">/</span>
+          <span className="text-shabrang-ink">{fm.title}</span>
+        </nav>
+
+        <header className="mb-8">
+          <h1 className="font-display text-3xl md:text-4xl text-shabrang-ink mb-4 uppercase tracking-wide">
+            {fm.title}
+          </h1>
+          <div className="flex flex-wrap gap-4 text-sm text-shabrang-ink-dim">
+            <span>{fm.author || 'Shabrang'}</span>
+            {fm.date && <span>{fm.date}</span>}
+            <span className="font-mono text-xs">{readTime}</span>
+          </div>
+
+          {fm.tags && (
+            <div className="flex flex-wrap gap-2 mt-3">
+              {fm.tags.map((tag) => (
+                <Link
+                  key={tag}
+                  href={`${basePath}/tags/${encodeURIComponent(tag)}`}
+                  className="text-[0.65rem] uppercase tracking-wider px-2.5 py-1 border-2 border-shabrang-teal/30 text-shabrang-ink-dim hover:text-shabrang-gold hover:border-shabrang-gold transition-colors"
+                >
+                  {tag}
+                </Link>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {fm.abstract ? (
+          <blockquote className="border-l-3 border-shabrang-gold pl-4 text-shabrang-ink-dim italic mb-8">
+            {fm.abstract}
+          </blockquote>
+        ) : null}
+
+        <div className="content-body" suppressHydrationWarning>
+          <MarkdownContent html={renderedBody} glossary={glossary} />
+        </div>
+
+        {pageBacklinks.length > 0 && (
+          <section className="backlinks mt-16 pt-10 border-t border-shabrang-teal/20">
+            <h3 className="text-xs font-medium text-shabrang-ink-dim uppercase tracking-[0.2em] mb-6">
+              Linked from
+            </h3>
+            <ul className="grid sm:grid-cols-2 gap-4">
+              {pageBacklinks.map((linkId) => {
+                const item = glossary[linkId];
+                const href = item?.url || `${basePath}/articles/${linkId}`;
+                return (
+                  <li key={linkId}>
+                    <Link href={href} className="card block p-4 group">
+                      <span className="text-shabrang-ink group-hover:text-shabrang-gold transition-colors text-sm">
+                        {item?.title || linkId}
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+      </PageShell>
+    </>
+  );
+}
+

--- a/src/app/[lang]/articles/page.tsx
+++ b/src/app/[lang]/articles/page.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { getArticles, getLanguages, getStaticPageAlternates, matchesPerspectiveView } from '@/lib/content';
+import { ArticlesSidebar } from '@/components/ArticlesSidebar';
+import { getLangBasePath } from '@/lib/site';
+
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('articles');
+  return {
+    title: 'Articles',
+    description: 'Long-form writing and essays in Shabrang.',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
+
+export function generateStaticParams() {
+  return getLanguages().map((lang) => ({ lang }));
+}
+
+export default async function ArticlesPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  const basePath = getLangBasePath(lang);
+  const articles = getArticles(lang).filter((a) => matchesPerspectiveView(a.frontmatter.perspective, 'kasra'));
+
+  return (
+    <main className="shabrang-page">
+      <div className="shabrang-container">
+        <div className="shabrang-layout">
+          <ArticlesSidebar lang={lang} basePath={basePath} view="kasra" variant="mobile" />
+          <ArticlesSidebar lang={lang} basePath={basePath} view="kasra" />
+          <div className="shabrang-content-full">
+            <div className="max-w-4xl mx-auto px-6 py-12">
+              <header className="mb-12">
+                <h1 className="text-3xl font-light text-frc-gold mb-3">Articles</h1>
+                <p className="text-frc-text-dim">
+                  Longer-form writing, essays, and primers.
+                </p>
+              </header>
+
+              {articles.length === 0 ? (
+                <div className="text-frc-text-dim text-sm border border-frc-blue rounded-lg p-6">
+                  No articles published yet.
+                </div>
+              ) : (
+                <ul className="space-y-4">
+                  {articles.map((a) => (
+                    <li key={a.frontmatter.id}>
+                      <Link href={`${basePath}/articles/${a.frontmatter.id}`} className="card block p-6 group">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="min-w-0">
+                            <h2 className="text-frc-text group-hover:text-frc-gold transition-colors font-medium">
+                              {a.frontmatter.title}
+                            </h2>
+                            {a.frontmatter.abstract && (
+                              <p className="text-sm text-frc-text-dim mt-2 leading-relaxed line-clamp-3">
+                                {a.frontmatter.abstract}
+                              </p>
+                            )}
+                          </div>
+                          <div className="text-right shrink-0">
+                            {a.frontmatter.date ? (
+                              <div className="text-xs text-frc-steel">{a.frontmatter.date}</div>
+                            ) : null}
+                          </div>
+                        </div>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/[lang]/blog/[id]/page.tsx
+++ b/src/app/[lang]/blog/[id]/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { SchemaScript } from '@/components/SchemaScript';
-import { schemaPaperPage, schemaFAQ, type FAQItem } from '@/lib/schema';
+import { schemaBlogPosting, schemaFAQ, type FAQItem } from '@/lib/schema';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { ContentDigest } from '@/components/ContentDigest';
 import { BlogSidebar } from '@/components/BlogSidebar';
@@ -13,7 +13,7 @@ import { VoiceTag } from '@/components/VoiceTag';
 import { GitHubDialectic } from '@/components/GitHubDialectic';
 import { RelatedPosts } from '@/components/RelatedPosts';
 import { FeaturedSidebar } from '@/components/FeaturedSidebar';
-import { estimateReadTime, getBlogPost, getBlogPosts, getLanguages, toPaperMeta, buildBacklinks, getGlossary, getAlternateLanguages, matchesPerspectiveView } from '@/lib/content';
+import { estimateReadTime, getBlogPost, getBlogPosts, getLanguages, buildBacklinks, getGlossary, getAlternateLanguages, matchesPerspectiveView } from '@/lib/content';
 import { renderMarkdown, extractTocItems } from '@/lib/markdown';
 import { getLangBasePath } from '@/lib/site';
 
@@ -73,7 +73,6 @@ export default async function BlogPostPage({ params }: Props) {
 
   const basePath = getLangBasePath(lang);
   const homeHref = basePath || '/';
-  const meta = toPaperMeta(post);
   const backlinks = buildBacklinks(lang);
   const pageBacklinks = backlinks[id] || [];
   const glossary = getGlossary(lang, { basePath, view: 'kasra' });
@@ -113,7 +112,18 @@ export default async function BlogPostPage({ params }: Props) {
 
   return (
     <>
-      <SchemaScript data={schemaPaperPage(meta)} />
+      <SchemaScript
+        data={schemaBlogPosting({
+          id: fm.id,
+          title: fm.title,
+          description: fm.abstract || '',
+          lang,
+          date: fm.date,
+          author: fm.author,
+          tags: fm.tags,
+          url: `https://shabrang.ca${basePath}/blog/${fm.id}`,
+        })}
+      />
       {faqData && faqData.length > 0 && (
         <SchemaScript data={schemaFAQ(faqData)} />
       )}

--- a/src/app/[lang]/blog/page.tsx
+++ b/src/app/[lang]/blog/page.tsx
@@ -1,13 +1,21 @@
 import type { Metadata } from 'next';
-import { getLanguages } from '@/lib/content';
+import { getLanguages, getStaticPageAlternates } from '@/lib/content';
 import { BlogIndex } from '@/components/pages/BlogIndex';
 import { BlogSidebar } from '@/components/BlogSidebar';
 import { getLangBasePath } from '@/lib/site';
 
-export const metadata: Metadata = {
-  title: 'Blog',
-  description: 'Down-to-earth notes and field reports from the Fractal Resonance Cognition project.',
-};
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('blog');
+  return {
+    title: 'Blog',
+    description: 'Essays and field notes from Shabrang — Persian wisdom through dialogue.',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
 
 export function generateStaticParams() {
   return getLanguages().map((lang) => ({ lang }));

--- a/src/app/[lang]/books/[id]/chapter/[chapter]/page.tsx
+++ b/src/app/[lang]/books/[id]/chapter/[chapter]/page.tsx
@@ -61,12 +61,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!ch) return { title: 'Not Found' };
 
   const fm = book.frontmatter;
-  const author = fm.author || 'H. Servat';
+  const author = fm.author || 'Kay Hermes';
   
-  // Logical Canonical: Technical FRC books point to fractalresonance.com, 
-  // while the primary narrative (Liquid Fortress) is canonical to shabrang.ca
-  const isTechnicalFrc = fm.id.startsWith('frc-');
-  const canonicalBase = isTechnicalFrc ? 'https://fractalresonance.com' : 'https://shabrang.ca';
+  // Canonical URLs should reflect the domain we want indexed.
+  const canonicalBase = 'https://shabrang.ca';
   const langPrefix = lang === 'en' ? '' : `/${lang}`;
   const bookUrl = `${canonicalBase}${langPrefix}/books/${fm.id}`;
   const chapterUrl = `${bookUrl}/chapter/${ch.slug}`;
@@ -161,7 +159,7 @@ export default async function BookChapterPage({ params }: Props) {
               <h1 className="text-2xl text-shabrang-ink mb-3">{current.title}</h1>
 
               <div className="flex flex-wrap gap-4 text-sm text-shabrang-ink-dim mt-3">
-                <span>{book.frontmatter.author || 'H. Servat'}</span>
+                <span>{book.frontmatter.author || 'Kay Hermes'}</span>
                 {book.frontmatter.date && <span>{book.frontmatter.date}</span>}
                 <span className="font-mono text-xs">{readTime}</span>
                 <Link href={`${basePath}/books/${id}`} className="tag hover:text-shabrang-gold hover:border-shabrang-gold transition-colors">

--- a/src/app/[lang]/books/[id]/page.tsx
+++ b/src/app/[lang]/books/[id]/page.tsx
@@ -4,8 +4,8 @@ import type { Metadata } from 'next';
 import { SchemaScript } from '@/components/SchemaScript';
 import { BooksSidebar } from '@/components/BooksSidebar';
 import { PageShell } from '@/components/PageShell';
-import { getBook, getBooks, getLanguages, toPaperMeta, getAlternateLanguages, matchesPerspectiveView } from '@/lib/content';
-import { schemaPaperPage } from '@/lib/schema';
+import { getBook, getBooks, getLanguages, getAlternateLanguages, matchesPerspectiveView } from '@/lib/content';
+import { schemaBook } from '@/lib/schema';
 import { getChapterList } from '@/lib/bookChapters';
 import { getLangBasePath } from '@/lib/site';
 
@@ -35,12 +35,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!book) return { title: 'Not Found' };
 
   const fm = book.frontmatter;
-  const author = fm.author || 'H. Servat';
+  const author = fm.author || 'Kay Hermes';
   
-  // Logical Canonical: Technical FRC books point to fractalresonance.com, 
-  // while the primary narrative (Liquid Fortress) is canonical to shabrang.ca
-  const isTechnicalFrc = fm.id.startsWith('frc-');
-  const canonicalBase = isTechnicalFrc ? 'https://fractalresonance.com' : 'https://shabrang.ca';
+  // Canonical URLs should reflect the domain we want indexed.
+  const canonicalBase = 'https://shabrang.ca';
   const langPrefix = lang === 'en' ? '' : `/${lang}`;
   const bookUrl = `${canonicalBase}${langPrefix}/books/${fm.id}`;
   
@@ -73,13 +71,24 @@ export default async function BookPage({ params }: Props) {
 
   const basePath = getLangBasePath(lang);
   const homeHref = basePath || '/';
-  const meta = toPaperMeta(book);
   const fm = book.frontmatter;
   const chapterItems = getChapterList(book.body);
 
   return (
     <>
-      <SchemaScript data={schemaPaperPage(meta)} />
+      <SchemaScript
+        data={schemaBook({
+          id: fm.id,
+          title: fm.title,
+          description: fm.abstract || '',
+          author: fm.author,
+          date: fm.date,
+          lang,
+          tags: fm.tags,
+          url: `https://shabrang.ca${basePath}/books/${fm.id}`,
+          image: fm.cover,
+        })}
+      />
 
       <PageShell
         leftMobile={<BooksSidebar lang={lang} currentId={id} chapters={chapterItems} basePath={basePath} view="kasra" variant="mobile" />}

--- a/src/app/[lang]/concepts/[id]/page.tsx
+++ b/src/app/[lang]/concepts/[id]/page.tsx
@@ -1,0 +1,178 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { SchemaScript } from '@/components/SchemaScript';
+import { schemaConceptPage } from '@/lib/schema';
+import { MarkdownContent } from '@/components/MarkdownContent';
+import { ConceptsSidebar } from '@/components/ConceptsSidebar';
+import { TableOfContents } from '@/components/TableOfContents';
+import { PageShell } from '@/components/PageShell';
+import {
+  estimateReadTime,
+  getConcept,
+  getConcepts,
+  getLanguages,
+  buildBacklinks,
+  getGlossary,
+  getAlternateLanguages,
+  matchesPerspectiveView,
+} from '@/lib/content';
+import { renderMarkdown, extractTocItems } from '@/lib/markdown';
+import { getLangBasePath } from '@/lib/site';
+
+interface Props {
+  params: Promise<{ lang: string; id: string }>;
+}
+
+export async function generateStaticParams() {
+  const languages = getLanguages();
+  const params: { lang: string; id: string }[] = [];
+
+  for (const lang of languages) {
+    const concepts = getConcepts(lang);
+    for (const c of concepts) {
+      if (c.frontmatter.id && matchesPerspectiveView(c.frontmatter.perspective, 'kasra')) {
+        params.push({ lang, id: c.frontmatter.id });
+      }
+    }
+  }
+
+  return params;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { lang, id } = await params;
+  const concept = getConcept(lang, id);
+  if (!concept) return { title: 'Not Found' };
+
+  const fm = concept.frontmatter;
+  const basePath = getLangBasePath(lang);
+  const url = `https://shabrang.ca${basePath}/concepts/${fm.id}`;
+  const alternates = getAlternateLanguages('concepts', fm.id);
+
+  return {
+    title: fm.title,
+    description: fm.abstract,
+    keywords: fm.tags,
+    alternates: {
+      canonical: url,
+      languages: alternates,
+    },
+    openGraph: {
+      type: 'article',
+      title: fm.title,
+      description: fm.abstract,
+      publishedTime: fm.date,
+      authors: [fm.author || 'Shabrang'],
+      tags: fm.tags,
+      locale: lang,
+      url,
+    },
+  };
+}
+
+export default async function ConceptPage({ params }: Props) {
+  const { lang, id } = await params;
+  const concept = getConcept(lang, id);
+  if (!concept) notFound();
+  if (!matchesPerspectiveView(concept.frontmatter.perspective, 'kasra')) notFound();
+
+  const basePath = getLangBasePath(lang);
+  const homeHref = basePath || '/';
+  const glossary = getGlossary(lang, { basePath, view: 'kasra' });
+  const backlinks = buildBacklinks(lang);
+  const pageBacklinks = backlinks[id] || [];
+  const fm = concept.frontmatter;
+
+  const readTime = fm.read_time || estimateReadTime(concept.body);
+  const renderedBody = renderMarkdown(concept.body, lang, glossary, basePath);
+  const tocItems = extractTocItems(concept.body).filter((t) => t.level === 2);
+
+  const firstPara = concept.body
+    .split('\n\n')
+    .find((p) => p && !p.startsWith('#') && !p.startsWith('---'))
+    ?.replace(/\[\[|\]\]/g, '')
+    .slice(0, 220) || '';
+
+  return (
+    <>
+      <SchemaScript
+        data={schemaConceptPage({
+          id: fm.id,
+          title: fm.title,
+          description: firstPara,
+          tags: fm.tags || [],
+          related: fm.related || [],
+          lang,
+        })}
+      />
+
+      <PageShell
+        leftMobile={<ConceptsSidebar lang={lang} currentId={id} basePath={basePath} view="kasra" variant="mobile" />}
+        leftDesktop={<ConceptsSidebar lang={lang} currentId={id} basePath={basePath} view="kasra" />}
+        right={<TableOfContents items={tocItems} />}
+      >
+        <nav className="text-sm text-shabrang-ink-dim mb-8">
+          <a href={homeHref} className="hover:text-shabrang-gold">Shabrang</a>
+          <span className="mx-2">/</span>
+          <a href={`${basePath}/concepts`} className="hover:text-shabrang-gold">Concepts</a>
+          <span className="mx-2">/</span>
+          <span className="text-shabrang-ink">{fm.title}</span>
+        </nav>
+
+        <header className="mb-8">
+          <h1 className="font-display text-3xl md:text-4xl text-shabrang-ink mb-4 uppercase tracking-wide">
+            {fm.title}
+          </h1>
+          <div className="flex flex-wrap gap-4 text-sm text-shabrang-ink-dim">
+            <span>{fm.author || 'Shabrang'}</span>
+            {fm.date && <span>{fm.date}</span>}
+            <span className="font-mono text-xs">{readTime}</span>
+          </div>
+
+          {fm.tags && (
+            <div className="flex flex-wrap gap-2 mt-3">
+              {fm.tags.map((tag) => (
+                <Link
+                  key={tag}
+                  href={`${basePath}/tags/${encodeURIComponent(tag)}`}
+                  className="text-[0.65rem] uppercase tracking-wider px-2.5 py-1 border-2 border-shabrang-teal/30 text-shabrang-ink-dim hover:text-shabrang-gold hover:border-shabrang-gold transition-colors"
+                >
+                  {tag}
+                </Link>
+              ))}
+            </div>
+          )}
+        </header>
+
+        <div className="content-body" suppressHydrationWarning>
+          <MarkdownContent html={renderedBody} glossary={glossary} />
+        </div>
+
+        {pageBacklinks.length > 0 && (
+          <section className="backlinks mt-16 pt-10 border-t border-shabrang-teal/20">
+            <h3 className="text-xs font-medium text-shabrang-ink-dim uppercase tracking-[0.2em] mb-6">
+              Linked from
+            </h3>
+            <ul className="grid sm:grid-cols-2 gap-4">
+              {pageBacklinks.map((linkId) => {
+                const item = glossary[linkId];
+                const href = item?.url || `${basePath}/concepts/${linkId}`;
+                return (
+                  <li key={linkId}>
+                    <Link href={href} className="card block p-4 group">
+                      <span className="text-shabrang-ink group-hover:text-shabrang-gold transition-colors text-sm">
+                        {item?.title || linkId}
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+      </PageShell>
+    </>
+  );
+}
+

--- a/src/app/[lang]/concepts/page.tsx
+++ b/src/app/[lang]/concepts/page.tsx
@@ -1,15 +1,15 @@
 import type { Metadata } from 'next';
 import { getLanguages, getStaticPageAlternates } from '@/lib/content';
-import { BooksIndex } from '@/components/pages/BooksIndex';
-import { BooksSidebar } from '@/components/BooksSidebar';
+import { ConceptsIndex } from '@/components/pages/ConceptsIndex';
+import { ConceptsSidebar } from '@/components/ConceptsSidebar';
 import { getLangBasePath } from '@/lib/site';
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
   const { lang } = await params;
-  const alternates = getStaticPageAlternates('books');
+  const alternates = getStaticPageAlternates('concepts');
   return {
-    title: 'Books',
-    description: 'Long-form reading in Shabrang: The Liquid Fortress and other works.',
+    title: 'Concepts',
+    description: 'Key terms and connective concepts used across Shabrang.',
     alternates: {
       canonical: alternates[lang] || alternates.en,
       languages: alternates,
@@ -21,24 +21,22 @@ export function generateStaticParams() {
   return getLanguages().map((lang) => ({ lang }));
 }
 
-interface Props {
-  params: Promise<{ lang: string }>;
-}
-
-export default async function BooksPage({ params }: Props) {
+export default async function ConceptsPage({ params }: { params: Promise<{ lang: string }> }) {
   const { lang } = await params;
   const basePath = getLangBasePath(lang);
+
   return (
     <main className="shabrang-page">
       <div className="shabrang-container">
         <div className="shabrang-layout">
-          <BooksSidebar lang={lang} basePath={basePath} view="kasra" variant="mobile" />
-          <BooksSidebar lang={lang} basePath={basePath} view="kasra" />
+          <ConceptsSidebar lang={lang} basePath={basePath} view="kasra" variant="mobile" />
+          <ConceptsSidebar lang={lang} basePath={basePath} view="kasra" />
           <div className="shabrang-content-full">
-            <BooksIndex lang={lang} basePath={basePath} view="kasra" embedded />
+            <ConceptsIndex lang={lang} basePath={basePath} view="kasra" embedded />
           </div>
         </div>
       </div>
     </main>
   );
 }
+

--- a/src/app/[lang]/contact/page.tsx
+++ b/src/app/[lang]/contact/page.tsx
@@ -1,16 +1,28 @@
 import type { Metadata } from 'next';
-import { getLanguages } from '@/lib/content';
+import { getLanguages, getStaticPageAlternates } from '@/lib/content';
+import { getLangBasePath } from '@/lib/site';
 
-export const metadata: Metadata = {
-  title: 'Contact',
-  description: 'Connect with Shabrang for inquiries and collaborations.',
-};
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('contact');
+  return {
+    title: 'Contact',
+    description: 'Connect with Shabrang for inquiries and collaborations.',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
 
 export function generateStaticParams() {
   return getLanguages().map((lang) => ({ lang }));
 }
 
-export default function ContactPage() {
+export default async function ContactPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  const basePath = getLangBasePath(lang);
+
   return (
     <main className="max-w-4xl mx-auto px-6 py-16">
       <div className="flex items-center gap-4 mb-12">
@@ -45,6 +57,13 @@ export default function ContactPage() {
 
         <p className="text-xs text-frc-text-dim leading-relaxed">
           Thank you for your interest in Shabrang.
+        </p>
+
+        <p className="text-xs text-frc-text-dim leading-relaxed">
+          Prefer to start with context? See the{' '}
+          <a className="hover:text-frc-gold" href={`${basePath}/about`}>
+            About page
+          </a>.
         </p>
       </section>
     </main>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { CommandPalette } from '@/components/CommandPalette';
 import { TranslationBadge } from '@/components/TranslationBadge';
 
 // RTL languages
@@ -16,7 +15,6 @@ export default async function LangLayout({ children, params }: LayoutProps) {
 
   return (
     <div dir={isRTL ? 'rtl' : 'ltr'} lang={lang} className={isRTL ? 'font-farsi' : ''}>
-      <CommandPalette />
       <TranslationBadge lang={lang} />
       {children}
     </div>

--- a/src/app/[lang]/papers/page.tsx
+++ b/src/app/[lang]/papers/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from 'next';
+import { getLanguages, getStaticPageAlternates, getPapers } from '@/lib/content';
+import { getLangBasePath } from '@/lib/site';
+import Link from 'next/link';
+
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('papers');
+  return {
+    title: 'Papers',
+    description: 'Research papers and technical notes (when published).',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
+
+export function generateStaticParams() {
+  return getLanguages().map((lang) => ({ lang }));
+}
+
+export default async function PapersPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  const basePath = getLangBasePath(lang);
+  const papers = getPapers(lang);
+
+  return (
+    <main className="max-w-4xl mx-auto px-6 py-16">
+      <div className="flex items-center gap-4 mb-12">
+        <h1 className="text-3xl font-light text-frc-gold tracking-tight">Papers</h1>
+        <div className="h-px flex-1 bg-gradient-to-r from-frc-blue to-transparent" />
+      </div>
+
+      {papers.length === 0 ? (
+        <div className="border border-frc-blue rounded-lg p-6 text-sm text-frc-text-dim">
+          No papers published yet.
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {papers.map((p) => (
+            <li key={p.frontmatter.id}>
+              <Link href={`${basePath}/papers/${p.frontmatter.id}`} className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
+                {p.frontmatter.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-10 flex flex-wrap gap-3">
+        <Link href={`${basePath}/books`} className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
+          Books
+        </Link>
+        <Link href={`${basePath}/blog`} className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
+          Blog
+        </Link>
+        <Link href={`${basePath}/topics`} className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
+          Topics
+        </Link>
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/[lang]/people/[id]/page.tsx
+++ b/src/app/[lang]/people/[id]/page.tsx
@@ -1,0 +1,134 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { MarkdownContent } from '@/components/MarkdownContent';
+import { PageShell } from '@/components/PageShell';
+import { PeopleSidebar } from '@/components/PeopleSidebar';
+import { getPerson, getPeople, getLanguages, getGlossary, getAlternateLanguages, matchesPerspectiveView } from '@/lib/content';
+import { renderMarkdown } from '@/lib/markdown';
+import { getLangBasePath } from '@/lib/site';
+
+interface Props {
+  params: Promise<{ lang: string; id: string }>;
+}
+
+export async function generateStaticParams() {
+  const languages = getLanguages();
+  const params: { lang: string; id: string }[] = [];
+
+  for (const lang of languages) {
+    const people = getPeople(lang);
+    for (const p of people) {
+      if (p.frontmatter.id && matchesPerspectiveView(p.frontmatter.perspective, 'kasra')) {
+        params.push({ lang, id: p.frontmatter.id });
+      }
+    }
+  }
+
+  return params;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { lang, id } = await params;
+  const person = getPerson(lang, id);
+  if (!person) return { title: 'Not Found' };
+
+  const fm = person.frontmatter;
+  const basePath = getLangBasePath(lang);
+  const url = `https://shabrang.ca${basePath}/people/${fm.id}`;
+  const alternates = getAlternateLanguages('people', fm.id);
+
+  return {
+    title: fm.title,
+    description: fm.tagline || fm.abstract,
+    keywords: fm.tags,
+    alternates: {
+      canonical: url,
+      languages: alternates,
+    },
+    openGraph: {
+      type: 'profile',
+      title: fm.title,
+      description: fm.tagline || fm.abstract,
+      locale: lang,
+      url,
+      ...(fm.avatar ? { images: [fm.avatar] } : {}),
+    },
+  };
+}
+
+export default async function PersonPage({ params }: Props) {
+  const { lang, id } = await params;
+  const person = getPerson(lang, id);
+  if (!person) notFound();
+  if (!matchesPerspectiveView(person.frontmatter.perspective, 'kasra')) notFound();
+
+  const basePath = getLangBasePath(lang);
+  const homeHref = basePath || '/';
+  const glossary = getGlossary(lang, { basePath, view: 'kasra' });
+  const fm = person.frontmatter;
+  const renderedBody = renderMarkdown(person.body, lang, glossary, basePath);
+
+  return (
+    <PageShell
+      leftMobile={<PeopleSidebar lang={lang} currentId={id} basePath={basePath} view="kasra" variant="mobile" />}
+      leftDesktop={<PeopleSidebar lang={lang} currentId={id} basePath={basePath} view="kasra" />}
+      articleClassName="shabrang-content-full"
+    >
+      <nav className="text-sm text-shabrang-ink-dim mb-8">
+        <a href={homeHref} className="hover:text-shabrang-gold">Shabrang</a>
+        <span className="mx-2">/</span>
+        <a href={`${basePath}/people`} className="hover:text-shabrang-gold">People</a>
+        <span className="mx-2">/</span>
+        <span className="text-shabrang-ink">{fm.title}</span>
+      </nav>
+
+      <header className="mb-10 flex items-start gap-6">
+        {fm.avatar ? (
+          <div className="relative w-16 h-16 rounded-full overflow-hidden border border-shabrang-gold/40 bg-shabrang-ink/10 shrink-0">
+            <Image src={fm.avatar} alt={fm.title} fill className="object-cover" />
+          </div>
+        ) : null}
+
+        <div className="min-w-0">
+          <h1 className="font-display text-3xl md:text-4xl text-shabrang-ink uppercase tracking-wide">
+            {fm.title}
+          </h1>
+          <div className="mt-2 text-sm text-shabrang-ink-dim flex flex-wrap gap-3">
+            {fm.role ? <span>{fm.role}</span> : null}
+            {fm.tagline ? <span className="italic">{fm.tagline}</span> : null}
+            {fm.perspective ? <span className="font-mono text-xs">{fm.perspective}</span> : null}
+          </div>
+
+          {Array.isArray(fm.links) && fm.links.length > 0 ? (
+            <div className="mt-4 flex flex-wrap gap-3">
+              {fm.links.map((l, idx) => {
+                const href = l?.url ? String(l.url) : '';
+                if (!href) return null;
+                const label = l?.label ? String(l.label) : href;
+                const isExternal = href.startsWith('http');
+                return (
+                  <a
+                    key={`${href}-${idx}`}
+                    href={href}
+                    target={isExternal ? '_blank' : undefined}
+                    rel={isExternal ? 'noopener noreferrer' : undefined}
+                    className="text-xs uppercase tracking-wider px-3 py-2 border-2 border-shabrang-teal/30 text-shabrang-ink-dim hover:text-shabrang-gold hover:border-shabrang-gold transition-colors"
+                  >
+                    {label}
+                  </a>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="content-body" suppressHydrationWarning>
+        <MarkdownContent html={renderedBody} glossary={glossary} />
+      </div>
+    </PageShell>
+  );
+}
+

--- a/src/app/[lang]/people/page.tsx
+++ b/src/app/[lang]/people/page.tsx
@@ -1,15 +1,15 @@
 import type { Metadata } from 'next';
 import { getLanguages, getStaticPageAlternates } from '@/lib/content';
-import { BooksIndex } from '@/components/pages/BooksIndex';
-import { BooksSidebar } from '@/components/BooksSidebar';
+import { PeopleIndex } from '@/components/pages/PeopleIndex';
+import { PeopleSidebar } from '@/components/PeopleSidebar';
 import { getLangBasePath } from '@/lib/site';
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
   const { lang } = await params;
-  const alternates = getStaticPageAlternates('books');
+  const alternates = getStaticPageAlternates('people');
   return {
-    title: 'Books',
-    description: 'Long-form reading in Shabrang: The Liquid Fortress and other works.',
+    title: 'People',
+    description: 'Site personas and contributors.',
     alternates: {
       canonical: alternates[lang] || alternates.en,
       languages: alternates,
@@ -21,24 +21,22 @@ export function generateStaticParams() {
   return getLanguages().map((lang) => ({ lang }));
 }
 
-interface Props {
-  params: Promise<{ lang: string }>;
-}
-
-export default async function BooksPage({ params }: Props) {
+export default async function PeoplePage({ params }: { params: Promise<{ lang: string }> }) {
   const { lang } = await params;
   const basePath = getLangBasePath(lang);
+
   return (
     <main className="shabrang-page">
       <div className="shabrang-container">
         <div className="shabrang-layout">
-          <BooksSidebar lang={lang} basePath={basePath} view="kasra" variant="mobile" />
-          <BooksSidebar lang={lang} basePath={basePath} view="kasra" />
+          <PeopleSidebar lang={lang} basePath={basePath} view="kasra" variant="mobile" />
+          <PeopleSidebar lang={lang} basePath={basePath} view="kasra" />
           <div className="shabrang-content-full">
-            <BooksIndex lang={lang} basePath={basePath} view="kasra" embedded />
+            <PeopleIndex lang={lang} basePath={basePath} view="kasra" embedded />
           </div>
         </div>
       </div>
     </main>
   );
 }
+

--- a/src/app/[lang]/privacy/page.tsx
+++ b/src/app/[lang]/privacy/page.tsx
@@ -1,16 +1,28 @@
 import type { Metadata } from 'next';
-import { getLanguages } from '@/lib/content';
+import { getLanguages, getStaticPageAlternates } from '@/lib/content';
+import { getLangBasePath } from '@/lib/site';
 
-export const metadata: Metadata = {
-  title: 'Privacy Policy',
-  description: 'Privacy Policy for Shabrang (shabrang.ca)',
-};
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('privacy');
+  return {
+    title: 'Privacy Policy',
+    description: 'Privacy Policy for Shabrang (shabrang.ca)',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
 
 export function generateStaticParams() {
   return getLanguages().map(lang => ({ lang }));
 }
 
-export default function PrivacyPage() {
+export default async function PrivacyPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  const basePath = getLangBasePath(lang);
+
   return (
     <main className="max-w-4xl mx-auto px-6 py-16">
       <div className="flex items-center gap-4 mb-12">
@@ -100,7 +112,7 @@ export default function PrivacyPage() {
           <p className="text-frc-text-dim leading-relaxed">
             For questions about this Privacy Policy, please contact us through the
             channels listed on our
-            <a href="/en/about" className="text-frc-gold hover:underline ml-1">About page</a>.
+            <a href={`${basePath}/about`} className="text-frc-gold hover:underline ml-1">About page</a>.
           </p>
         </section>
       </div>

--- a/src/app/[lang]/start/page.tsx
+++ b/src/app/[lang]/start/page.tsx
@@ -1,0 +1,300 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SchemaScript } from '@/components/SchemaScript';
+import { PageShell } from '@/components/PageShell';
+import { getLanguages, getStaticPageAlternates } from '@/lib/content';
+import { schemaFAQ, type FAQItem } from '@/lib/schema';
+import { getLangBasePath } from '@/lib/site';
+
+function getCopy(lang: string) {
+  const isFA = lang === 'fa';
+
+  if (isFA) {
+    const faqs: FAQItem[] = [
+      {
+        question: 'شبرنگ چیست؟',
+        answer:
+          'شبرنگ یک پروژهٔ هنری-فلسفی است که تلاش می‌کند «حکمت ایرانی» را به شکل یک گفت‌وگوی زنده نشان دهد: از فرهنگ روزمره تا اسطوره، از ساختار تا معنا.',
+      },
+      {
+        question: '«دژِ سیال» چیست؟',
+        answer:
+          '«دژِ سیال» (The Liquid Fortress) کتابِ شبرنگ است: ۳۰ فصلِ مصور دربارهٔ این‌که ایران چگونه در طول ۳۰۰۰ سالِ سقوط و هجوم، معنای خود را حفظ کرده است.',
+      },
+      {
+        question: 'از کجا شروع کنم؟',
+        answer:
+          'اگر ۵ دقیقه وقت دارید: این صفحه را بخوانید و سپس «مطالعهٔ ضروری» را ببینید. اگر ۱ ساعت وقت دارید: چند پستِ شروع + چند فصلِ رایگانِ کتاب را بخوانید.',
+      },
+      {
+        question: 'این سایت چه زبان‌هایی دارد؟',
+        answer:
+          'انگلیسی و فارسی. برخی بخش‌ها ممکن است هنوز در حال ترجمه باشند.',
+      },
+      {
+        question: 'چطور می‌توانم در گفت‌وگو شرکت کنم؟',
+        answer:
+          'روی هر صفحه می‌توانید «Add Your Voice» را بزنید و نظر خود را در GitHub Discussions ثبت کنید.',
+      },
+    ];
+
+    return {
+      title: 'شروع کنید: شبرنگ چیست؟',
+      description:
+        'نقشهٔ ورود به شبرنگ: دژِ سیال چیست، برای چه کسی است، و بهترین مسیرِ مطالعه برای شروع.',
+      eyebrow: 'نقشهٔ ورود',
+      headline: 'شروع کنید: شبرنگ چیست؟',
+      subhead:
+        'شبرنگ یک گفت‌وگوی زنده دربارهٔ «معماریِ بقا»ست: هنر + فلسفه + روحِ ایران، از آدابِ روزمره تا اسطوره و ساختار.',
+      oneLinerTitle: 'در یک جمله',
+      oneLiner:
+        'شبرنگ تلاش می‌کند نشان دهد ایران چگونه معنای خود را «سیال» نگه داشت تا با هر سقوط، دوباره بازسازی شود.',
+      pathsTitle: 'مسیرِ پیشنهادی',
+      paths: [
+        {
+          title: 'کتاب را از فصل‌های رایگان شروع کنید',
+          desc: '۵ فصل اول رایگان است. اگر دنبال یک روایتِ پیوسته هستید، این بهترین نقطهٔ شروع است.',
+          href: '/books/liquid-fortress',
+          cta: 'شروع مطالعهٔ رایگان',
+        },
+        {
+          title: 'مطالعهٔ ضروری (پست‌های کوتاه‌تر)',
+          desc: 'هستهٔ ایده‌ها با مثال‌های ملموس از فرهنگِ ایرانی.',
+          href: '/blog',
+          cta: 'دیدن پست‌ها',
+        },
+        {
+          title: 'موضوعات (مرور بر اساس سؤال)',
+          desc: 'اگر با یک سؤال خاص آمده‌اید، از این‌جا وارد شوید.',
+          href: '/topics',
+          cta: 'مرور موضوعات',
+        },
+      ],
+      themesTitle: 'پنج دروازهٔ سریع',
+      themes: [
+        { title: 'آداب و امنیت اجتماعی', href: '/blog/adab-social-handshake' },
+        { title: 'تعارف به‌مثابهٔ نظریهٔ بازی', href: '/blog/taarof-game-theory' },
+        { title: 'قنات و شبکهٔ غیرمتمرکز', href: '/blog/qanats-decentralized-grid' },
+        { title: 'شاهنامه به‌عنوان حافظهٔ تمدنی', href: '/blog/shahnameh-civilizational-hard-drive' },
+        { title: 'سیمرغ و هوشِ جمعی', href: '/blog/simurgh-swarm-intelligence' },
+      ],
+      faqTitle: 'سوالات پرتکرار',
+      faqs,
+    };
+  }
+
+  const faqs: FAQItem[] = [
+    {
+      question: 'What is Shabrang?',
+      answer:
+        'Shabrang is an art + philosophy project that explores Persian wisdom through a living dialectic—moving between structure and meaning, everyday culture and myth.',
+    },
+    {
+      question: 'What is The Liquid Fortress?',
+      answer:
+        'The Liquid Fortress is Shabrang’s illustrated book: 30 chapters on how Persian culture preserved meaning through 3,000 years of invasion, collapse, and renewal.',
+    },
+    {
+      question: 'Where should I start?',
+      answer:
+        'If you have 5 minutes: read this page, then skim Essential Reading. If you have 1 hour: read a few starter posts, then the free chapters of the book.',
+    },
+    {
+      question: 'Is Shabrang available in multiple languages?',
+      answer:
+        'Yes—English and Farsi. Some sections may still be in translation.',
+    },
+    {
+      question: 'How do I join the conversation?',
+      answer:
+        'On most pages you can click “Add Your Voice” to leave a comment via GitHub Discussions.',
+    },
+  ];
+
+  return {
+    title: 'Start Here: What is Shabrang?',
+    description:
+      'A clear entry point to Shabrang: what it is, who it’s for, and the best reading path to begin with The Liquid Fortress.',
+    eyebrow: 'Start Here',
+    headline: 'Start Here: What is Shabrang?',
+    subhead:
+      'Shabrang is a living dialectic about survival architecture: art + philosophy + the Persian spirit, from everyday protocol to myth and structure.',
+    oneLinerTitle: 'In one sentence',
+    oneLiner:
+      'Shabrang explores how Persian culture kept meaning “liquid” enough to survive collapse—so identity could rebuild, again and again.',
+    pathsTitle: 'Choose a path',
+    paths: [
+      {
+        title: 'Read the book (free chapters)',
+        desc: 'The first chapters are free. Best if you want the full narrative arc.',
+        href: '/books/liquid-fortress',
+        cta: 'Start Reading Free',
+      },
+      {
+        title: 'Essential Reading (shorter posts)',
+        desc: 'Core ideas explained through everyday Persian cultural artifacts.',
+        href: '/blog',
+        cta: 'Browse Posts',
+      },
+      {
+        title: 'Browse by question (Topics)',
+        desc: 'If you arrived with a specific question, start from a topic hub.',
+        href: '/topics',
+        cta: 'Explore Topics',
+      },
+    ],
+    themesTitle: 'Five fast entry points',
+    themes: [
+      { title: 'Adab as social security', href: '/blog/adab-social-handshake' },
+      { title: 'Taarof as game theory', href: '/blog/taarof-game-theory' },
+      { title: 'Qanats as decentralized infrastructure', href: '/blog/qanats-decentralized-grid' },
+      { title: 'Shahnameh as civilizational memory', href: '/blog/shahnameh-civilizational-hard-drive' },
+      { title: 'Simurgh as swarm intelligence', href: '/blog/simurgh-swarm-intelligence' },
+    ],
+    faqTitle: 'FAQ',
+    faqs,
+  };
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('start');
+  const copy = getCopy(lang);
+
+  return {
+    title: copy.title,
+    description: copy.description,
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
+
+export function generateStaticParams() {
+  return getLanguages().map((lang) => ({ lang }));
+}
+
+export default async function StartHerePage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  const basePath = getLangBasePath(lang);
+  const copy = getCopy(lang);
+
+  const faqSchema = schemaFAQ(copy.faqs.map((f) => ({ question: f.question, answer: f.answer })));
+
+  return (
+    <>
+      <SchemaScript data={faqSchema} />
+      <PageShell withReadingMode={false} articleClassName="shabrang-content-full">
+        <div className="max-w-5xl mx-auto px-6 py-14">
+          <div className="mb-10">
+            <p className="font-display text-xs uppercase tracking-[0.35em] text-shabrang-teal mb-4">
+              {copy.eyebrow}
+            </p>
+            <h1 className="font-display text-4xl sm:text-5xl text-shabrang-gold uppercase tracking-widest leading-[1.1]">
+              {copy.headline}
+            </h1>
+            <p className="mt-6 text-shabrang-parchment/80 text-lg leading-relaxed max-w-3xl">
+              {copy.subhead}
+            </p>
+          </div>
+
+          <div className="border-2 border-shabrang-gold bg-shabrang-parchment-dark/10 p-8 sm:p-10 mb-12">
+            <h2 className="font-display text-xl text-shabrang-gold uppercase tracking-widest mb-4">
+              {copy.oneLinerTitle}
+            </h2>
+            <p className="text-shabrang-parchment/85 leading-relaxed text-base sm:text-lg">
+              {copy.oneLiner}
+            </p>
+          </div>
+
+          <div className="mb-14">
+            <h2 className="font-display text-2xl text-shabrang-gold uppercase tracking-widest mb-6">
+              {copy.pathsTitle}
+            </h2>
+            <div className="grid gap-5 md:grid-cols-3">
+              {copy.paths.map((p) => (
+                <div
+                  key={p.href}
+                  className="border border-shabrang-teal/40 bg-shabrang-parchment-dark/5 p-6 hover:border-shabrang-gold transition-colors"
+                >
+                  <h3 className="font-display text-sm uppercase tracking-widest text-shabrang-parchment mb-3">
+                    {p.title}
+                  </h3>
+                  <p className="text-shabrang-parchment/75 text-sm leading-relaxed mb-5">
+                    {p.desc}
+                  </p>
+                  <Link
+                    href={`${basePath}${p.href}`}
+                    className="inline-block px-5 py-3 bg-shabrang-gold text-shabrang-ink font-display text-xs uppercase tracking-widest hover:bg-shabrang-parchment transition-all"
+                  >
+                    {p.cta}
+                  </Link>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="mb-14">
+            <h2 className="font-display text-2xl text-shabrang-gold uppercase tracking-widest mb-6">
+              {copy.themesTitle}
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {copy.themes.map((t) => (
+                <Link
+                  key={t.href}
+                  href={`${basePath}${t.href}`}
+                  className="border border-shabrang-teal/30 bg-shabrang-parchment-dark/5 px-5 py-4 hover:border-shabrang-gold transition-colors"
+                >
+                  <span className="text-shabrang-parchment/85 text-sm leading-relaxed">
+                    {t.title}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-t border-shabrang-teal/30 pt-12">
+            <h2 className="font-display text-2xl text-shabrang-gold uppercase tracking-widest mb-6">
+              {copy.faqTitle}
+            </h2>
+            <div className="space-y-6">
+              {copy.faqs.map((f) => (
+                <div key={f.question} className="border border-shabrang-teal/25 bg-shabrang-parchment-dark/5 p-6">
+                  <h3 className="font-display text-sm uppercase tracking-widest text-shabrang-parchment mb-3">
+                    {f.question}
+                  </h3>
+                  <p className="text-shabrang-parchment/75 text-sm leading-relaxed">
+                    {f.answer}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-10 flex flex-wrap gap-3">
+              <Link
+                href={`${basePath}/books/liquid-fortress`}
+                className="inline-block px-6 py-3 border-2 border-shabrang-gold text-shabrang-gold font-display text-xs uppercase tracking-widest hover:bg-shabrang-gold hover:text-shabrang-ink transition-all"
+              >
+                {lang === 'fa' ? 'شروع مطالعهٔ کتاب' : 'Start the Book'}
+              </Link>
+              <Link
+                href={`${basePath}/blog`}
+                className="inline-block px-6 py-3 border border-shabrang-teal text-shabrang-parchment/80 font-display text-xs uppercase tracking-widest hover:border-shabrang-gold transition-all"
+              >
+                {lang === 'fa' ? 'مطالعهٔ ضروری' : 'Essential Reading'}
+              </Link>
+              <Link
+                href={`${basePath}/about`}
+                className="inline-block px-6 py-3 border border-shabrang-teal text-shabrang-parchment/80 font-display text-xs uppercase tracking-widest hover:border-shabrang-gold transition-all"
+              >
+                {lang === 'fa' ? 'دربارهٔ شبرنگ' : 'About Shabrang'}
+              </Link>
+            </div>
+          </div>
+        </div>
+      </PageShell>
+    </>
+  );
+}
+

--- a/src/app/[lang]/terms/page.tsx
+++ b/src/app/[lang]/terms/page.tsx
@@ -1,16 +1,28 @@
 import type { Metadata } from 'next';
-import { getLanguages } from '@/lib/content';
+import { getLanguages, getStaticPageAlternates } from '@/lib/content';
+import { getLangBasePath } from '@/lib/site';
 
-export const metadata: Metadata = {
-  title: 'Terms of Service',
-  description: 'Terms of Service for Shabrang (shabrang.ca)',
-};
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('terms');
+  return {
+    title: 'Terms of Service',
+    description: 'Terms of Service for Shabrang (shabrang.ca)',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
 
 export function generateStaticParams() {
   return getLanguages().map(lang => ({ lang }));
 }
 
-export default function TermsPage() {
+export default async function TermsPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  const basePath = getLangBasePath(lang);
+
   return (
     <main className="max-w-4xl mx-auto px-6 py-16">
       <div className="flex items-center gap-4 mb-12">
@@ -112,7 +124,7 @@ export default function TermsPage() {
           <p className="text-frc-text-dim leading-relaxed">
             For questions about these Terms of Service, please contact us through the
             channels listed on our
-            <a href="/en/about" className="text-frc-gold hover:underline ml-1">About page</a>.
+            <a href={`${basePath}/about`} className="text-frc-gold hover:underline ml-1">About page</a>.
           </p>
         </section>
       </div>

--- a/src/app/[lang]/topics/page.tsx
+++ b/src/app/[lang]/topics/page.tsx
@@ -1,13 +1,21 @@
 import type { Metadata } from 'next';
-import { getLanguages } from '@/lib/content';
+import { getLanguages, getStaticPageAlternates } from '@/lib/content';
 import { TopicsIndex } from '@/components/pages/TopicsIndex';
 import { TopicsSidebar } from '@/components/TopicsSidebar';
 import { getLangBasePath } from '@/lib/site';
 
-export const metadata: Metadata = {
-  title: 'Topics',
-  description: 'Questions, summaries, and spectrum views across the Fractal Resonance Cognition corpus.',
-};
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const alternates = getStaticPageAlternates('topics');
+  return {
+    title: 'Topics',
+    description: 'Guides and question-led hubs across Shabrang (culture, philosophy, myth).',
+    alternates: {
+      canonical: alternates[lang] || alternates.en,
+      languages: alternates,
+    },
+  };
+}
 
 export function generateStaticParams() {
   return getLanguages().map((lang) => ({ lang }));

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -1,5 +1,6 @@
-export { metadata } from '@/app/[lang]/art/page';
-import ArtPage from '@/app/[lang]/art/page';
+import ArtPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/art/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
 
 export default function Page() {
   return ArtPage({ params: Promise.resolve({ lang: 'en' }) });

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,0 +1,17 @@
+import ArticlePage, {
+  generateStaticParams as generateLangStaticParams,
+  generateMetadata as generateLangMetadata,
+} from '@/app/[lang]/articles/[id]/page';
+
+export async function generateStaticParams() {
+  const params = await generateLangStaticParams();
+  return params.filter((p) => p.lang === 'en').map((p) => ({ id: p.id }));
+}
+
+export const generateMetadata = ({ params }: { params: Promise<{ id: string }> }) =>
+  generateLangMetadata({ params: params.then(({ id }) => ({ lang: 'en', id })) });
+
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return ArticlePage({ params: params.then(({ id }) => ({ lang: 'en', id })) });
+}
+

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,0 +1,8 @@
+import ArticlesPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/articles/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return ArticlesPage({ params: Promise.resolve({ lang: 'en' }) });
+}
+

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,6 @@
-export { metadata } from '@/app/[lang]/blog/page';
-import BlogPage from '@/app/[lang]/blog/page';
+import BlogPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/blog/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
 
 export default function Page() {
   return BlogPage({ params: Promise.resolve({ lang: 'en' }) });

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,5 +1,6 @@
-export { metadata } from '@/app/[lang]/books/page';
-import BooksPage from '@/app/[lang]/books/page';
+import BooksPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/books/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
 
 export default function Page() {
   return BooksPage({ params: Promise.resolve({ lang: 'en' }) });

--- a/src/app/concepts/[id]/page.tsx
+++ b/src/app/concepts/[id]/page.tsx
@@ -1,0 +1,17 @@
+import ConceptPage, {
+  generateStaticParams as generateLangStaticParams,
+  generateMetadata as generateLangMetadata,
+} from '@/app/[lang]/concepts/[id]/page';
+
+export async function generateStaticParams() {
+  const params = await generateLangStaticParams();
+  return params.filter((p) => p.lang === 'en').map((p) => ({ id: p.id }));
+}
+
+export const generateMetadata = ({ params }: { params: Promise<{ id: string }> }) =>
+  generateLangMetadata({ params: params.then(({ id }) => ({ lang: 'en', id })) });
+
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return ConceptPage({ params: params.then(({ id }) => ({ lang: 'en', id })) });
+}
+

--- a/src/app/concepts/page.tsx
+++ b/src/app/concepts/page.tsx
@@ -1,0 +1,8 @@
+import ConceptsPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/concepts/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return ConceptsPage({ params: Promise.resolve({ lang: 'en' }) });
+}
+

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,7 @@
-export { metadata } from '@/app/[lang]/contact/page';
-import ContactPage from '@/app/[lang]/contact/page';
+import ContactPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/contact/page';
 
-export default ContactPage;
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return ContactPage({ params: Promise.resolve({ lang: 'en' }) });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
     template: '%s | Shabrang',
   },
   description: 'Art, philosophy, and the Persian spirit. The Liquid Fortress book, albums, and explorations of coherence through Persian aesthetics.',
-  keywords: ['Shabrang', 'Liquid Fortress', 'Persian art', 'Persian philosophy', 'coherence', 'miniature', 'Hadi Servat'],
+  keywords: ['Shabrang', 'The Liquid Fortress', 'Persian art', 'Persian philosophy', 'coherence', 'Iranian culture', 'Kay Hermes'],
   authors: [{ name: 'Kay Hermes' }],
   metadataBase: new URL('https://shabrang.ca'),
   openGraph: {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -12,17 +12,16 @@ export default function NotFound() {
       </p>
 
       <div className="flex flex-wrap gap-3">
-        <Link href="/en/papers" className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
-          Go to Papers
+        <Link href="/books" className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
+          Go to Books
         </Link>
-        <Link href="/en/blog" className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
+        <Link href="/blog" className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
           Go to Blog
         </Link>
-        <Link href="/en/topics" className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
+        <Link href="/topics" className="tag hover:text-frc-gold hover:border-frc-gold transition-colors">
           Go to Topics
         </Link>
       </div>
     </main>
   );
 }
-

--- a/src/app/papers/page.tsx
+++ b/src/app/papers/page.tsx
@@ -1,0 +1,8 @@
+import PapersPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/papers/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return PapersPage({ params: Promise.resolve({ lang: 'en' }) });
+}
+

--- a/src/app/people/[id]/page.tsx
+++ b/src/app/people/[id]/page.tsx
@@ -1,0 +1,17 @@
+import PersonPage, {
+  generateStaticParams as generateLangStaticParams,
+  generateMetadata as generateLangMetadata,
+} from '@/app/[lang]/people/[id]/page';
+
+export async function generateStaticParams() {
+  const params = await generateLangStaticParams();
+  return params.filter((p) => p.lang === 'en').map((p) => ({ id: p.id }));
+}
+
+export const generateMetadata = ({ params }: { params: Promise<{ id: string }> }) =>
+  generateLangMetadata({ params: params.then(({ id }) => ({ lang: 'en', id })) });
+
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return PersonPage({ params: params.then(({ id }) => ({ lang: 'en', id })) });
+}
+

--- a/src/app/people/page.tsx
+++ b/src/app/people/page.tsx
@@ -1,0 +1,8 @@
+import PeoplePage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/people/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return PeoplePage({ params: Promise.resolve({ lang: 'en' }) });
+}
+

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,7 @@
-export { metadata } from '@/app/[lang]/privacy/page';
-import PrivacyPage from '@/app/[lang]/privacy/page';
+import PrivacyPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/privacy/page';
 
-export default PrivacyPage;
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return PrivacyPage({ params: Promise.resolve({ lang: 'en' }) });
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://shabrang.ca/sitemap.xml',
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -90,7 +90,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   });
 
   // Static pages with language alternates (only pages that exist)
-  const staticPages = ['about', 'books', 'art', 'blog', 'topics', 'concepts', 'articles', 'people', 'papers', 'contact', 'privacy', 'terms'];
+  const staticPages = ['start', 'about', 'books', 'art', 'blog', 'topics', 'concepts', 'articles', 'people', 'papers', 'contact', 'privacy', 'terms'];
 
   for (const page of staticPages) {
     const alternates = getStaticPageAlternates(page);
@@ -99,7 +99,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
       if (!url) continue;
 
       const lastMs =
-        page === 'about'
+        page === 'start'
+          ? safeFileMtimeMs('src/app/[lang]/start/page.tsx')
+          : page === 'about'
           ? safeContentFileMtimeMs(lang, 'about')
           : page === 'privacy'
             ? safeFileMtimeMs('src/app/[lang]/privacy/page.tsx')

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,78 @@
 import type { MetadataRoute } from 'next';
-import { getBooks, getBlogPosts, getTopics, getArtItems, getLanguages, getAlternateLanguages, getStaticPageAlternates, getAllTags } from '@/lib/content';
+import { getBooks, getBlogPosts, getTopics, getArtItems, getConcepts, getArticles, getPeople, getPapers, getLanguages, getAlternateLanguages, getStaticPageAlternates, getAllTags } from '@/lib/content';
+import fs from 'fs';
+import path from 'path';
 
 export const dynamic = 'force-static';
 
 const SITE_URL = 'https://shabrang.ca';
 
+function safeDateMs(raw: unknown): number | null {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function maxMs(values: Array<number | null | undefined>): number | null {
+  let out: number | null = null;
+  for (const v of values) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) continue;
+    out = out === null ? v : Math.max(out, v);
+  }
+  return out;
+}
+
+function safeFileMtimeMs(relPathFromRepoRoot: string): number | null {
+  try {
+    const full = path.join(process.cwd(), relPathFromRepoRoot);
+    const stat = fs.statSync(full);
+    return stat.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function safeContentFileMtimeMs(lang: string, page: string): number | null {
+  const candidates = [
+    path.join('content', lang, 'site', `${page}.md`),
+    path.join('content', 'en', 'site', `${page}.md`),
+  ];
+  return maxMs(candidates.map((p) => safeFileMtimeMs(p)));
+}
+
+function latestItemDateMs(lang: string, getter: (lang: string) => any[]): number | null {
+  const items = getter(lang);
+  return maxMs(items.map((i) => safeDateMs(i?.frontmatter?.date)));
+}
+
+function latestContentDateMs(languages: string[]): number | null {
+  const values: Array<number | null> = [];
+  for (const lang of languages) {
+    values.push(latestItemDateMs(lang, getBlogPosts));
+    values.push(latestItemDateMs(lang, getBooks));
+    values.push(latestItemDateMs(lang, getArtItems));
+    values.push(latestItemDateMs(lang, getTopics));
+    values.push(latestItemDateMs(lang, getConcepts));
+    values.push(latestItemDateMs(lang, getArticles));
+    values.push(latestItemDateMs(lang, getPeople));
+    values.push(latestItemDateMs(lang, getPapers));
+  }
+  return maxMs(values);
+}
+
+function itemDateMsById(getter: (lang: string) => any[], lang: string, id: string): number | null {
+  const items = getter(lang);
+  const found = items.find((i) => i?.frontmatter?.id === id);
+  return safeDateMs(found?.frontmatter?.date);
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const languages = getLanguages();
+  const globalLastModifiedMs =
+    latestContentDateMs(languages) ??
+    safeFileMtimeMs('content') ??
+    safeFileMtimeMs('README.md') ??
+    Date.now();
   const entries: MetadataRoute.Sitemap = [];
 
   // Homepage with language alternates
@@ -17,22 +83,51 @@ export default function sitemap(): MetadataRoute.Sitemap {
   homeAlternates['x-default'] = `${SITE_URL}/`;
   entries.push({
     url: SITE_URL,
-    lastModified: new Date(),
+    lastModified: new Date(globalLastModifiedMs),
     changeFrequency: 'weekly',
     priority: 1.0,
     alternates: { languages: homeAlternates },
   });
 
   // Static pages with language alternates (only pages that exist)
-  const staticPages = ['about', 'books', 'art', 'blog', 'topics', 'contact', 'privacy', 'terms'];
+  const staticPages = ['about', 'books', 'art', 'blog', 'topics', 'concepts', 'articles', 'people', 'papers', 'contact', 'privacy', 'terms'];
 
   for (const page of staticPages) {
     const alternates = getStaticPageAlternates(page);
     for (const lang of languages) {
-      const langPrefix = lang === 'en' ? '' : `/${lang}`;
+      const url = alternates[lang];
+      if (!url) continue;
+
+      const lastMs =
+        page === 'about'
+          ? safeContentFileMtimeMs(lang, 'about')
+          : page === 'privacy'
+            ? safeFileMtimeMs('src/app/[lang]/privacy/page.tsx')
+            : page === 'terms'
+              ? safeFileMtimeMs('src/app/[lang]/terms/page.tsx')
+              : page === 'contact'
+                ? safeFileMtimeMs('src/app/[lang]/contact/page.tsx')
+                : page === 'blog'
+                  ? latestItemDateMs(lang, getBlogPosts)
+                  : page === 'books'
+                    ? latestItemDateMs(lang, getBooks)
+                    : page === 'art'
+                      ? latestItemDateMs(lang, getArtItems)
+                      : page === 'topics'
+                        ? latestItemDateMs(lang, getTopics)
+                        : page === 'concepts'
+                          ? latestItemDateMs(lang, getConcepts)
+                          : page === 'articles'
+                            ? latestItemDateMs(lang, getArticles)
+                            : page === 'people'
+                              ? latestItemDateMs(lang, getPeople)
+                              : page === 'papers'
+                                ? latestItemDateMs(lang, getPapers)
+                        : null;
+
       entries.push({
-        url: `${SITE_URL}${langPrefix}/${page}`,
-        lastModified: new Date(),
+        url,
+        lastModified: new Date(lastMs ?? globalLastModifiedMs),
         changeFrequency: 'monthly',
         priority: 0.8,
         alternates: { languages: alternates },
@@ -51,10 +146,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
         seenIds.add(id);
 
         const alternates = getAlternateLanguages(type as any, id);
-        for (const altLang of Object.keys(alternates).filter(l => l !== 'x-default')) {
+        for (const altLang of Object.keys(alternates).filter((l) => l !== 'x-default')) {
+          const lastMs = itemDateMsById(getter, altLang, id) ?? globalLastModifiedMs;
           entries.push({
             url: alternates[altLang],
-            lastModified: item.frontmatter.date ? new Date(item.frontmatter.date) : new Date(),
+            lastModified: new Date(lastMs),
             changeFrequency: 'monthly',
             priority,
             alternates: { languages: alternates },
@@ -69,6 +165,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
   addContentToSitemap('books', getBooks, 0.9);
   addContentToSitemap('art', getArtItems, 0.8);
   addContentToSitemap('topics', getTopics, 0.8);
+  addContentToSitemap('concepts', getConcepts, 0.75);
+  addContentToSitemap('articles', getArticles, 0.8);
+  addContentToSitemap('people', getPeople, 0.6);
+  addContentToSitemap('papers', getPapers, 0.6);
 
   // Tag archive pages
   for (const lang of languages) {
@@ -77,7 +177,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     for (const tag of tags) {
       entries.push({
         url: `${SITE_URL}${langPrefix}/tags/${tag}`,
-        lastModified: new Date(),
+        lastModified: new Date(globalLastModifiedMs),
         changeFrequency: 'weekly',
         priority: 0.7,
       });

--- a/src/app/start/page.tsx
+++ b/src/app/start/page.tsx
@@ -1,0 +1,8 @@
+import StartHerePage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/start/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return StartHerePage({ params: Promise.resolve({ lang: 'en' }) });
+}
+

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,7 @@
-export { metadata } from '@/app/[lang]/terms/page';
-import TermsPage from '@/app/[lang]/terms/page';
+import TermsPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/terms/page';
 
-export default TermsPage;
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
+
+export default function Page() {
+  return TermsPage({ params: Promise.resolve({ lang: 'en' }) });
+}

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -1,5 +1,6 @@
-export { metadata } from '@/app/[lang]/topics/page';
-import TopicsPage from '@/app/[lang]/topics/page';
+import TopicsPage, { generateMetadata as generateLangMetadata } from '@/app/[lang]/topics/page';
+
+export const generateMetadata = () => generateLangMetadata({ params: Promise.resolve({ lang: 'en' }) });
 
 export default function Page() {
   return TopicsPage({ params: Promise.resolve({ lang: 'en' }) });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,6 +23,7 @@ export function Header() {
 
   // Shabrang navigation
   const navLinks = [
+    { path: '/start', label: 'Start Here' },
     { path: '/books/liquid-fortress', label: 'Book' },
     { path: '/art', label: 'Art' },
     { path: '/blog', label: 'Blog' },

--- a/src/components/LandingGateway.tsx
+++ b/src/components/LandingGateway.tsx
@@ -44,7 +44,7 @@ export function LandingGateway() {
 
         {/* Title */}
         <h1 className="animate-fade-up stagger-1 text-4xl sm:text-5xl lg:text-6xl font-light text-frc-gold mb-6 tracking-tight">
-          Fractal Resonance
+          Shabrang
         </h1>
 
         {/* The Equation */}
@@ -53,7 +53,7 @@ export function LandingGateway() {
             dS + k<span className="text-frc-gold">*</span> d ln C = 0
           </p>
           <p className="font-mono text-xs text-frc-steel mt-3 uppercase tracking-widest">
-            The Law of Reciprocity
+            A living dialectic
           </p>
         </div>
 

--- a/src/components/TextSharePopover.tsx
+++ b/src/components/TextSharePopover.tsx
@@ -57,7 +57,7 @@ export function TextSharePopover() {
 
   const shareTwitter = useCallback(() => {
     const url = encodeURIComponent(window.location.href);
-    const text = encodeURIComponent(`"${popover.text.slice(0, 200)}${popover.text.length > 200 ? '...' : ''}" — FRC`);
+    const text = encodeURIComponent(`"${popover.text.slice(0, 200)}${popover.text.length > 200 ? '...' : ''}" — Shabrang`);
     window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}`, '_blank', 'width=550,height=420');
   }, [popover.text]);
 

--- a/src/components/pages/MuseumIndex.tsx
+++ b/src/components/pages/MuseumIndex.tsx
@@ -56,7 +56,7 @@ export function MuseumIndex({ basePath, items }: MuseumIndexProps) {
             Museum of Coherence
           </h1>
           <p className="text-shabrang-ink-dim text-lg md:text-xl max-w-2xl mx-auto leading-relaxed italic">
-            Reading history through the X-ray of FRC. Every artifact is a node in the 3,000-year flow of the Liquid Fortress.
+            Reading Persian history through the Shabrang lens. Every artifact is a node in the 3,000-year flow of the Liquid Fortress.
           </p>
         </header>
 

--- a/src/components/pages/ShabrangHome.tsx
+++ b/src/components/pages/ShabrangHome.tsx
@@ -1028,7 +1028,7 @@ export function ShabrangHome({ lang, featuredPosts = [] }: { lang: string; featu
               <Link href={`${basePath}/books/liquid-fortress/chapter/02-collapse`} className="chapter-card">
                 <span className="chapter-badge free">Free</span>
                 <div className="chapter-number">Chapter 2</div>
-                <h3 className="chapter-title">The Lens of FRC</h3>
+                <h3 className="chapter-title">The Lens of Coherence</h3>
                 <p className="chapter-meta">Methodology</p>
               </Link>
               <Link href={`${basePath}/books/liquid-fortress/chapter/03-binary`} className="chapter-card">

--- a/src/components/pages/ShabrangHome.tsx
+++ b/src/components/pages/ShabrangHome.tsx
@@ -745,13 +745,14 @@ export function ShabrangHome({ lang, featuredPosts = [] }: { lang: string; featu
                   <span>Art, Philosophy &amp; The Persian Spirit</span>
                 </div>
                 <h1 className="hero-title">The Liquid Fortress</h1>
-                <p className="hero-subtitle">A Structural History of the Persian Mind</p>
+                <p className="hero-subtitle">Shabrang’s Structural History of the Persian Mind</p>
                 <p className="hero-description">
-                  Why did Persia survive 3,000 years of invasion when every other ancient civilization died?
-                  Discover the architecture of meaning that could not be burned.
+                  Shabrang explores why Persia survived 3,000 years of invasion when other ancient civilizations disappeared —
+                  the architecture of meaning that could not be burned.
                 </p>
                 <div className="hero-cta">
-                  <Link href={`${basePath}/books/liquid-fortress`} className="btn btn-primary">Read Free Chapters</Link>
+                  <Link href={`${basePath}/start`} className="btn btn-primary">Start Here</Link>
+                  <Link href={`${basePath}/books/liquid-fortress`} className="btn btn-secondary">Read Free Chapters</Link>
                   <a href="https://www.amazon.com/LIQUID-FORTRESS-Structural-History-Persian-ebook/dp/B0GBJ47F5X" target="_blank" rel="noopener noreferrer" className="btn btn-secondary">Get the Book</a>
                 </div>
               </div>
@@ -835,7 +836,11 @@ export function ShabrangHome({ lang, featuredPosts = [] }: { lang: string; featu
             <div className="section-header">
               <h2 className="section-title">Essential Reading</h2>
               <p className="section-description">
-                Start here: The core ideas of the Liquid Fortress explained through everyday Persian cultural artifacts.
+                New to Shabrang?{' '}
+                <Link href={`${basePath}/start`} className="underline hover:no-underline">
+                  Start here
+                </Link>
+                : the core ideas of the Liquid Fortress explained through everyday Persian cultural artifacts.
               </p>
             </div>
             <FeaturedPosts posts={featuredPosts} basePath={`${basePath}`} />

--- a/src/lib/lenses.ts
+++ b/src/lib/lenses.ts
@@ -7,7 +7,7 @@ export interface LensDef {
 // Default lens registry.
 // This is intentionally small and conservative; users can extend it in their fork.
 export const LENSES: LensDef[] = [
-  { key: 'frc', label: 'FRC', group: 'frc' },
+  { key: 'frc', label: 'Shabrang', group: 'frc' },
   { key: 'kasra', label: 'Kasra (Architect)', group: 'frc' },
   { key: 'river', label: 'River (Oracle)', group: 'frc' },
 
@@ -35,4 +35,3 @@ export function getLensLabel(key: string): string {
   if (!k) return String(key || '');
   return LENSES.find((l) => l.key === k)?.label || key;
 }
-

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,8 +1,8 @@
 /**
- * Schema.org JSON-LD generators for FRC
+ * Schema.org JSON-LD generators for Shabrang
  *
  * 13 schema types:
- * Site-level: WebSite, SearchAction, ResearchProject, Organization, Person
+ * Site-level: WebSite, Organization, Person
  * Paper-level: ScholarlyArticle, VideoObject, ImageObject, AggregateRating,
  *              BreadcrumbList, CreativeWorkSeries, LearningResource
  * Concept-level: DefinedTerm, DefinedTermSet
@@ -10,6 +10,8 @@
  */
 
 const SITE_URL = 'https://shabrang.ca';
+const SITE_NAME = 'Shabrang';
+const AUTHOR_NAME = 'Kay Hermes';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -72,86 +74,145 @@ export interface BreadcrumbItem {
 
 // ─── Site-Level Schemas ────────────────────────────────────────────────────
 
-/** WebSite + SearchAction — enables sitelinks search box */
+/** WebSite — top-level site identity */
 export function schemaWebSite() {
   return {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     '@id': `${SITE_URL}/#website`,
-    name: 'Fractal Resonance Cognition',
+    name: SITE_NAME,
     url: SITE_URL,
-    description: 'Research platform for the Fractal Resonance Cognition framework — exploring consciousness, coherence, and quantum foundations.',
-    inLanguage: 'en',
-    potentialAction: {
-      '@type': 'SearchAction',
-      target: {
-        '@type': 'EntryPoint',
-        urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
-      },
-      'query-input': 'required name=search_term_string',
-    },
+    description: 'Persian wisdom through dialectic — a living conversation between opposing perspectives.',
   };
 }
 
-/** ResearchProject — FRC as an active research project */
-export function schemaResearchProject() {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'ResearchProject',
-    '@id': `${SITE_URL}/#project`,
-    name: 'Fractal Resonance Cognition (FRC)',
-    url: SITE_URL,
-    description: 'A research framework formalizing the reciprocal relationship between entropy and coherence, with applications in quantum mechanics, thermodynamics, and consciousness studies.',
-    foundingDate: '2024',
-    founder: { '@id': `${SITE_URL}/#author` },
-    knowsAbout: [
-      'Quantum Coherence',
-      'Entropy-Coherence Reciprocity',
-      'Universal Coherence Condition',
-      'Consciousness',
-      'Thermodynamics',
-    ],
-  };
-}
-
-/** Organization — Fractal Resonance entity */
+/** Organization — Shabrang publisher */
 export function schemaOrganization() {
   return {
     '@context': 'https://schema.org',
     '@type': 'Organization',
     '@id': `${SITE_URL}/#org`,
-    name: 'Fractal Resonance',
+    name: 'Shabrang',
     url: SITE_URL,
     logo: `${SITE_URL}/brand/logo.png`,
     sameAs: [
-      'https://github.com/servathadi/fractalresonance',
-      'https://zenodo.org/communities/frc',
+      'https://github.com/Digidinc/shabrang',
+      'https://github.com/Digidinc/shabrang-cms',
     ],
     founder: { '@id': `${SITE_URL}/#author` },
   };
 }
 
-/** Person — Author (Hadi Servat) */
+/** Person — Author */
 export function schemaPerson() {
   return {
     '@context': 'https://schema.org',
     '@type': 'Person',
     '@id': `${SITE_URL}/#author`,
-    name: 'Hadi Servat',
+    name: AUTHOR_NAME,
     url: SITE_URL,
-    sameAs: [
-      'https://orcid.org/0009-0004-7412-5129',
-      'https://www.researchgate.net/profile/Hadi-Servat',
-      'https://independent.academia.edu/HadiServat',
-      'https://github.com/servathadi',
-    ],
-    jobTitle: 'Researcher',
+    jobTitle: 'Writer',
     knowsAbout: [
-      'Fractal Resonance Coherence',
-      'Quantum Mechanics',
-      'Entropy',
-      'Coherence Theory',
+      'Persian philosophy',
+      'Iranian Plateau culture',
+      'Myth and symbolism',
+      'Dialectic',
     ],
+  };
+}
+
+// ─── Content-Level Schemas ─────────────────────────────────────────────────
+
+export interface BlogMeta {
+  id: string;
+  title: string;
+  description: string;
+  lang: string;
+  date?: string;
+  author?: string;
+  tags?: string[];
+  url?: string;
+  image?: string;
+}
+
+export function schemaBlogPosting(post: BlogMeta) {
+  const url = post.url || `${SITE_URL}/${post.lang}/blog/${post.id}`;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    '@id': url,
+    url,
+    headline: post.title,
+    name: post.title,
+    description: post.description,
+    datePublished: post.date,
+    inLanguage: post.lang,
+    author: post.author ? { '@type': 'Person', name: post.author } : { '@id': `${SITE_URL}/#author` },
+    publisher: { '@id': `${SITE_URL}/#org` },
+    keywords: post.tags,
+    ...(post.image ? { image: post.image } : {}),
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+  };
+}
+
+export interface BookMeta {
+  id: string;
+  title: string;
+  description: string;
+  lang: string;
+  author?: string;
+  date?: string;
+  tags?: string[];
+  url?: string;
+  image?: string;
+}
+
+export function schemaBook(book: BookMeta) {
+  const url = book.url || `${SITE_URL}/${book.lang}/books/${book.id}`;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Book',
+    '@id': url,
+    url,
+    name: book.title,
+    description: book.description,
+    inLanguage: book.lang,
+    datePublished: book.date,
+    author: book.author ? { '@type': 'Person', name: book.author } : { '@id': `${SITE_URL}/#author` },
+    publisher: { '@id': `${SITE_URL}/#org` },
+    keywords: book.tags,
+    ...(book.image ? { image: book.image } : {}),
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+  };
+}
+
+export interface ArtworkMeta {
+  id: string;
+  title: string;
+  description: string;
+  lang: string;
+  author?: string;
+  date?: string;
+  tags?: string[];
+  url?: string;
+  image?: string;
+}
+
+export function schemaVisualArtwork(art: ArtworkMeta) {
+  const url = art.url || `${SITE_URL}/${art.lang}/art/${art.id}`;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'VisualArtwork',
+    '@id': url,
+    url,
+    name: art.title,
+    description: art.description,
+    inLanguage: art.lang,
+    dateCreated: art.date,
+    creator: art.author ? { '@type': 'Person', name: art.author } : { '@id': `${SITE_URL}/#author` },
+    keywords: art.tags,
+    ...(art.image ? { image: art.image } : {}),
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
   };
 }
 
@@ -295,7 +356,7 @@ export function schemaTopicPage(topic: TopicMeta) {
   };
 }
 
-/** CreativeWorkSeries — paper series (FRC 100, 200, etc.) */
+/** CreativeWorkSeries — paper series */
 export function schemaCreativeWorkSeries(
   seriesName: string,
   papers: PaperMeta[]
@@ -330,10 +391,10 @@ export function schemaLearningResource(paper: PaperMeta) {
     teaches: paper.tags.map(tag => ({
       '@type': 'DefinedTerm',
       name: tag,
-      inDefinedTermSet: { '@id': `${SITE_URL}/#termset-frc` },
+      inDefinedTermSet: { '@id': `${SITE_URL}/#termset-shabrang` },
     })),
     inLanguage: paper.lang,
-    isPartOf: { '@id': `${SITE_URL}/#project` },
+    isPartOf: { '@id': `${SITE_URL}/#website` },
   };
 }
 
@@ -353,14 +414,14 @@ export function schemaBreadcrumbList(items: BreadcrumbItem[]) {
 
 // ─── Concept-Level Schemas ─────────────────────────────────────────────────
 
-/** DefinedTermSet — the FRC glossary */
+/** DefinedTermSet — site glossary */
 export function schemaDefinedTermSet(concepts: ConceptMeta[]) {
   return {
     '@context': 'https://schema.org',
     '@type': 'DefinedTermSet',
-    '@id': `${SITE_URL}/#termset-frc`,
-    name: 'FRC Concepts',
-    description: 'Core concepts and terminology of the Fractal Resonance Cognition framework.',
+    '@id': `${SITE_URL}/#termset-shabrang`,
+    name: 'Shabrang Concepts',
+    description: 'Key terms and connective concepts used across Shabrang.',
     url: `${SITE_URL}/en/concepts`,
     creator: { '@id': `${SITE_URL}/#author` },
     hasDefinedTerm: concepts.map(c => ({
@@ -369,7 +430,7 @@ export function schemaDefinedTermSet(concepts: ConceptMeta[]) {
       name: c.title,
       description: c.description,
       termCode: c.id,
-      inDefinedTermSet: { '@id': `${SITE_URL}/#termset-frc` },
+      inDefinedTermSet: { '@id': `${SITE_URL}/#termset-shabrang` },
     })),
   };
 }
@@ -385,8 +446,8 @@ export function schemaDefinedTerm(concept: ConceptMeta) {
     termCode: concept.id,
     inDefinedTermSet: {
       '@type': 'DefinedTermSet',
-      '@id': `${SITE_URL}/#termset-frc`,
-      name: 'FRC Concepts',
+      '@id': `${SITE_URL}/#termset-shabrang`,
+      name: 'Shabrang Concepts',
     },
     sameAs: concept.related.map(r => `${SITE_URL}/${concept.lang}/concepts/${r}`),
   };
@@ -400,47 +461,39 @@ export function schemaDataset() {
     '@context': 'https://schema.org',
     '@type': 'Dataset',
     '@id': `${SITE_URL}/#dataset`,
-    name: 'Fractal Resonance Cognition Research Data',
-    description: 'Structured research data from the FRC framework including papers, concepts, equations, and knowledge graph relationships.',
-    url: `${SITE_URL}/for-ai`,
+    name: 'Shabrang Site Index',
+    description: 'Machine-readable index files for Shabrang (site search index and LLM summary).',
+    url: `${SITE_URL}/llms.txt`,
     creator: { '@id': `${SITE_URL}/#author` },
-    license: 'https://opensource.org/licenses/BSL-1.1',
+    license: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
     distribution: [
       {
         '@type': 'DataDownload',
         encodingFormat: 'application/json',
-        contentUrl: `${SITE_URL}/api/concepts`,
-        name: 'FRC Concepts API',
-      },
-      {
-        '@type': 'DataDownload',
-        encodingFormat: 'application/json',
-        contentUrl: `${SITE_URL}/api/papers`,
-        name: 'FRC Papers API',
-      },
-      {
-        '@type': 'DataDownload',
-        encodingFormat: 'application/json',
-        contentUrl: `${SITE_URL}/api/graph`,
-        name: 'FRC Knowledge Graph API',
+        contentUrl: `${SITE_URL}/search-index.json`,
+        name: 'Site Search Index',
       },
       {
         '@type': 'DataDownload',
         encodingFormat: 'text/plain',
         contentUrl: `${SITE_URL}/llms.txt`,
-        name: 'FRC LLM Summary',
+        name: 'LLM Summary',
+      },
+      {
+        '@type': 'DataDownload',
+        encodingFormat: 'application/rss+xml',
+        contentUrl: `${SITE_URL}/feed.xml`,
+        name: 'RSS Feed',
       },
     ],
     keywords: [
-      'coherence',
-      'entropy',
-      'quantum mechanics',
-      'consciousness',
-      'FRC',
-      'fractal resonance',
+      'persian philosophy',
+      'iranian plateau',
+      'dialectic',
+      'shabrang',
+      'liquid fortress',
     ],
     isAccessibleForFree: true,
-    measurementTechnique: 'Theoretical framework with mathematical formalization',
   };
 }
 
@@ -452,7 +505,6 @@ export function schemaSiteGraph() {
     '@context': 'https://schema.org',
     '@graph': [
       { ...schemaWebSite(), '@context': undefined },
-      { ...schemaResearchProject(), '@context': undefined },
       { ...schemaOrganization(), '@context': undefined },
       { ...schemaPerson(), '@context': undefined },
     ],
@@ -462,8 +514,8 @@ export function schemaSiteGraph() {
 /** Generate all schemas for a paper page */
 export function schemaPaperPage(paper: PaperMeta) {
   const breadcrumbs = schemaBreadcrumbList([
-    { name: 'FRC', url: '/' },
-    { name: 'Papers', url: `/${paper.lang}/papers` },
+    { name: SITE_NAME, url: '/' },
+    { name: 'Library', url: '/' },
     { name: paper.title, url: `/${paper.lang}/papers/${paper.id}` },
   ]);
 
@@ -531,7 +583,7 @@ export function schemaChapter(chapter: ChapterMeta) {
 /** Generate all schemas for a concept page */
 export function schemaConceptPage(concept: ConceptMeta) {
   const breadcrumbs = schemaBreadcrumbList([
-    { name: 'FRC', url: '/' },
+    { name: SITE_NAME, url: '/' },
     { name: 'Concepts', url: `/${concept.lang}/concepts` },
     { name: concept.title, url: `/${concept.lang}/concepts/${concept.id}` },
   ]);


### PR DESCRIPTION
Goal: improve indexing + presentability for shabrang.ca.

Fixes #39

Changes:
- Add `/robots.txt` (static export compatible)
- Stabilize sitemap `lastModified` and include key sections
- Align schema.org JSON-LD + `llms.txt` with Shabrang (remove stale FRC dataset/API claims)
- Canonicals consistently point to `https://shabrang.ca`
- Add missing routes so internal links don’t 404: `/concepts`, `/people`, `/articles`, `/papers` (and `/fa` variants)
- Add a "Start Here" hub page (`/start`, `/fa/start`) with FAQ schema + clear internal linking path
- Update homepage hero + header nav to point new visitors to "Start Here"

Issues: #33 #34 #35 #36 #37
